### PR TITLE
Fix PowerShell array assignment for versions

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -28,7 +28,7 @@ jobs:
 
     - name: Run PowerShell script to get versions
       run: |
-        $versions = & ./.github/workflows/get-versions.ps1
+        $versions = @( & ./.github/workflows/get-versions.ps1 )
         if ($versions.Count -eq 0) {
           Write-Host "No versions found. Skipping Docker build and push."
           exit 0


### PR DESCRIPTION
This pull request makes a minor update to the PowerShell script invocation in the GitHub Actions workflow. The change ensures that the output from the `get-versions.ps1` script is always treated as an array, which helps prevent issues when the script returns a single value.

* Ensured `$versions` is always an array by wrapping the output of `get-versions.ps1` in `@()`, improving reliability when checking the count and handling the script output.